### PR TITLE
possibility to specify ROMEO and CLEARSWI binary path directly as input function to matlab wrappers

### DIFF
--- a/matlab/CLEARSWI.m
+++ b/matlab/CLEARSWI.m
@@ -1,12 +1,16 @@
 function [swi, mip] = CLEARSWI(mag, phase, parameters)
-    [filepath, ~,~] = fileparts(mfilename('fullpath'));
-    clearswi_path = fullfile(filepath, '..', 'bin');
-    clearswi_name = 'clearswi';
-    if ispc
-        clearswi_name = 'clearswi.exe';
+    if isfield(parameters, 'command') && ~isempty(parameters.command)
+        clearswi_binary = parameters.command;
+    else
+        [filepath, ~,~] = fileparts(mfilename('fullpath'));
+        clearswi_path = fullfile(filepath, '..', 'bin');
+        clearswi_name = 'clearswi';
+        if ispc
+            clearswi_name = 'clearswi.exe';
+        end
+        clearswi_binary = fullfile(clearswi_path, clearswi_name); 
     end
     
-    clearswi_binary = fullfile(clearswi_path, clearswi_name); 
     
     output_dir = pwd();
     if isfield(parameters, 'output_dir')

--- a/matlab/ROMEO.m
+++ b/matlab/ROMEO.m
@@ -1,11 +1,15 @@
 function [unwrapped, B0] = ROMEO(phase, parameters)
-    [filepath, ~,~] = fileparts(mfilename('fullpath'));
-    romeo_path = fullfile(filepath, '..', 'bin');
-    romeo_name = 'romeo';
-    if ispc
-        romeo_name = 'romeo.exe';
-    end
-    romeo_binary = fullfile(romeo_path, romeo_name); 
+	if isfield(parameters, 'command') && ~isempty(parameters.command)
+        romeo_binary = parameters.command;
+	else
+        [filepath, ~,~] = fileparts(mfilename('fullpath'));
+        romeo_path = fullfile(filepath, '..', 'bin');
+        romeo_name = 'romeo';
+        if ispc
+            romeo_name = 'romeo.exe';
+        end
+        romeo_binary = fullfile(romeo_path, romeo_name); 
+	end
     
     output_dir = pwd();
     if isfield(parameters, 'output_dir')


### PR DESCRIPTION
Very niche problem of mine I assume, but:

We are running very outdated software on our compute cluster, so I have to run everything in containers. Some Matlab based software declares MRITools as dependency and specifically uses ROMEO for preprocessing. However in that case, the matlab wrapper references the compiled binary which comes with MRITools. This is the step at which my code then fails. 

As a solution I added to possibility to add a 'command' flag to the input parameters which then takes precedence over the binary path from MRITools. The fallback if the command is not specified is still the MRITools binary. Therefore it should not break any existing implementations and just add functionality, if required.

Cheers and thanks for the awesome software