### PR TITLE
ci: pin actions to SHAs and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: cache-artifacts
         with:
@@ -33,5 +33,5 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # latest
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,12 +23,12 @@ jobs:
         arch:
           - 'x64'
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # latest
       - name: Compile
         run: julia --color=yes --project=@. -e 'using CompileMRI; compile()'
       - name: Get Version
@@ -48,7 +48,7 @@ jobs:
           echo "ZIP_TYPE=zip" >> $env:GITHUB_ENV
           Compress-Archive -Path 'compiled/*' -DestinationPath 'mritools_${{ matrix.os }}_${{ steps.version.outputs.version }}.zip'
       - name: Upload release
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Automated supply-chain hardening for GitHub Actions.

What this does:
- Pins every `uses: owner/action@tag` reference in `.github/workflows/` to the full 40-character commit SHA, with the original tag preserved as a trailing comment.
- Adds `.github/dependabot.yml` (if missing) so Dependabot keeps the pinned actions updated on a weekly schedule.

SHAs were resolved with `git ls-remote` against each action's repository (annotated tags dereferenced to their commit). Behavior is unchanged; this only replaces mutable tag references with immutable commit pins.
